### PR TITLE
fix: /articlesと/tags/[id]をリダイレクトからSSGに

### DIFF
--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from 'next/navigation'
+import ArticleListPage from './page/[current]/page'
 
 export default function Page() {
-  redirect('/articles/page/1')
+  return <ArticleListPage params={{ current: '1' }} />
 }

--- a/src/app/tags/[tagId]/page.tsx
+++ b/src/app/tags/[tagId]/page.tsx
@@ -1,9 +1,23 @@
-import { redirect } from 'next/navigation'
+import { getTagsList } from '@/features/article/server/microcms'
+
+import ArticleListFilterByTagPage from './page//[current]/page'
 
 type Props = {
   params: { tagId: string }
 }
 
+export async function generateStaticParams() {
+  const { contents: tags } = await getTagsList()
+
+  const paths = tags.map((tag) => {
+    return {
+      tagId: tag.id,
+    }
+  })
+
+  return paths
+}
+
 export default function Page({ params: { tagId } }: Props) {
-  redirect(`/tags/${tagId}/page/1`)
+  return <ArticleListFilterByTagPage params={{ current: '1', tagId: tagId }} />
 }


### PR DESCRIPTION
リダイレクトだとVercelのServerless Functionが遅い